### PR TITLE
WIP - Add etc/ folder to syspath for easier customization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ BUILDOUT_ARGS = -N buildout:directory=$(ROOT_DIR) buildout:user=$(user)
 
 etc/settings.ini:
 	mkdir -p etc/
+	touch etc/__init__.py
 	cp conf/settings.ini.sample etc/settings.ini
 	chmod -f 600 etc/settings.ini
 

--- a/conf/buildout.cfg
+++ b/conf/buildout.cfg
@@ -39,6 +39,7 @@ wsgi = true
 eggs =
     ${gdal-bindings:egg}
     ${buildout:eggs}
+extra-paths = ${buildout:directory}/etc
 # Django upload root (see FileField.upload_to)
 uploadroot = ${django:mediaroot}/${django:uploaddir}
 

--- a/docs/advanced-configuration.rst
+++ b/docs/advanced-configuration.rst
@@ -11,11 +11,11 @@ Geotrek configuration is currently restricted to values present in ``etc/setting
 
 However, it is still possible to write a custom Django setting file.
 
-* Create your a file in *geotrek/settings/custom.py* with the following content :
+* Create your a file in *etc/custom.py* with the following content :
 
 .. code-block :: python
 
-    from .prod import *
+    from geotrek.settings.prod import *
 
     # My custom value
     HIDDEN_OPTION = 3.14
@@ -25,7 +25,7 @@ However, it is still possible to write a custom Django setting file.
 .. code-block :: ini
 
     [django]
-    settings = settings.custom
+    settings = custom
 
 * As for any change in settings, re-run ``make env_standalone deploy``.
 


### PR DESCRIPTION
Currently, because of isotoma.recipe.django, settings have to be within project. This is painful because we cannot keep all configurations aspects outside source folder (in ``etc/``).

This is an old branch, I open the PR to draw a bit of attention...
