### PR TITLE
Fix snapping when a path has very close points

### DIFF
--- a/geotrek/core/tests/test_models.py
+++ b/geotrek/core/tests/test_models.py
@@ -163,3 +163,17 @@ class PathGeometryTest(TestCase):
         # Snap both
         path_snapped = PathFactory.create(geom=LineString((0, 0), (3.0, 0)))
         self.assertEqual(path_snapped.geom.coords, ((0, 0), (3.0, math.sin(3))))
+
+    def test_snapping_choose_closest_point(self):
+        # Line with several points in less than PATH_SNAPPING_DISTANCE
+        PathFactory.create(geom=LineString((0, 0), (9.8, 0), (9.9, 0), (10, 0)))
+        path_snapped = PathFactory.create(geom=LineString((10, 0.1), (10, 10)))
+        self.assertEqual(path_snapped.geom.coords, ((10, 0), (10, 10)))
+
+    def test_snapping_is_idempotent(self):
+        PathFactory.create(geom=LineString((0, 0), (9.8, 0), (9.9, 0), (10, 0)))
+        path_snapped = PathFactory.create(geom=LineString((10, 0.1), (10, 10)))
+        old_geom = path_snapped.geom
+        path_snapped.geom = old_geom
+        path_snapped.save()
+        self.assertEqual(path_snapped.geom.coords, old_geom.coords)


### PR DESCRIPTION
If path A has very close points A1 and A2 (less than snapping distance). If path B has a point B1 at the same location as A1. The current algorithm may choose to snap B1 to A2. If A1 was path end, A will be splitted at A2. The new path A' between A1 and A2 will be very short and A1 may snap to B1 ie to A1. So the new path will get a null length and become an invalid geometry -> crash! This fix ensures that the snapping points always the closest.