### PR TITLE
Properly configure settings.LANGUAGES from ini file

### DIFF
--- a/geotrek/settings/default.py
+++ b/geotrek/settings/default.py
@@ -61,9 +61,9 @@ CACHES['fat']['TIMEOUT'] = envini.getint('cachetimeout', 3600 * 24)
 
 
 LANGUAGE_CODE = envini.get('language', LANGUAGE_CODE, env=False)
+LANGUAGES = [l for l in LANGUAGES_LIST if l[0] in envini.getstrings('languages')]
 MODELTRANSLATION_DEFAULT_LANGUAGE = LANGUAGE_CODE
-_MODELTRANSLATION_LANGUAGES = [l for l in LANGUAGES_LIST
-                               if l[0] in envini.getstrings('languages')]
+_MODELTRANSLATION_LANGUAGES = LANGUAGES
 MODELTRANSLATION_LANGUAGES = [l[0] for l in _MODELTRANSLATION_LANGUAGES]
 
 TITLE = envini.get('title', MAPENTITY_CONFIG['TITLE'])


### PR DESCRIPTION
Without that, choosing different languages from the current defaults leads to errors like:
```
File ".../geotrek/geotrek/trekking/views.py", line 29, in <module>
    from .forms import TrekForm, TrekRelationshipFormSet, POIForm, WebLinkCreateFormPopup
  File ".../geotrek/geotrek/trekking/forms.py", line 196, in <module>
    class WebLinkCreateFormPopup(forms.ModelForm):
  File ".../virtualenvs/geotrek/local/lib/python2.7/site-packages/django/forms/models.py", line 292, in __new__
    raise FieldError(message)
FieldError: Unknown field(s) (name_de) specified for WebLink
```