### PR TITLE
update requirements / unbreak install

### DIFF
--- a/conf/buildout-dev.cfg
+++ b/conf/buildout-dev.cfg
@@ -36,3 +36,4 @@ entry-points = convertit=pyramid.scripts.pserve:main
 
 [versions]
 pyparsing = 1.5.7
+django-debug-toolbar = 1.3.2

--- a/conf/buildout.cfg
+++ b/conf/buildout.cfg
@@ -132,6 +132,7 @@ cffi = 1.1.2
 WeasyPrint = 0.23
 django-weasyprint = 0.1
 lxml = 3.4.4
+django-celery = 3.1.16
 
 [sources]
 #


### PR DESCRIPTION
django-celery and django-debug-toolbar update problems

fixed with last compatible version with django 1.6